### PR TITLE
Api versioning

### DIFF
--- a/app/controllers/v3/api_controller.rb
+++ b/app/controllers/v3/api_controller.rb
@@ -26,4 +26,8 @@ class V3::ApiController < ActionController::API
   def current_resource_owner
     User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
   end
+
+  def api_version
+    request.headers["X-Api-Version"].to_i
+  end
 end

--- a/app/controllers/v3/streams/enclosures_controller.rb
+++ b/app/controllers/v3/streams/enclosures_controller.rb
@@ -61,6 +61,9 @@ class V3::Streams::EnclosuresController < V3::ApiController
       @enclosure_class.set_marks(current_resource_owner, @items)
     end
     @enclosure_class.set_contents(@items)
+    if api_version == 0
+      @items = @items.select {|i| i.legacy? }
+    end
     h = {
       direction: "ltr",
       continuation: continuation,

--- a/app/controllers/v3/streams_controller.rb
+++ b/app/controllers/v3/streams_controller.rb
@@ -30,6 +30,7 @@ class V3::StreamsController < V3::ApiController
     if @need_visual
       @entries = @entries.select { |entry| entry.has_visual? }
     end
+    Entry.set_contents_of_enclosures(@entries)
     h = {
       direction: "ltr",
       continuation: continuation,

--- a/app/controllers/v3/streams_controller.rb
+++ b/app/controllers/v3/streams_controller.rb
@@ -31,11 +31,12 @@ class V3::StreamsController < V3::ApiController
       @entries = @entries.select { |entry| entry.has_visual? }
     end
     Entry.set_contents_of_enclosures(@entries)
+    only_legacy = api_version == 0
     h = {
       direction: "ltr",
       continuation: continuation,
       alternate: [],
-      items: @entries.map { |en| en.as_content_json }
+      items: @entries.map { |en| en.as_content_json(only_legacy: only_legacy) }
     }
     if @feed.present?
       h[:updated] = @feed.updated_at.to_time.to_i * 1000

--- a/app/models/enclosure.rb
+++ b/app/models/enclosure.rb
@@ -1,4 +1,5 @@
 class Enclosure < ApplicationRecord
+  LEGACY_PROVIDERS = ["YouTube", "SoundCloud"]
   attr_accessor :content
   include Likable
   include Savable
@@ -82,6 +83,10 @@ class Enclosure < ApplicationRecord
       items.select { |t| t.id == h[:id] }.first
     }
     PaginatedArray.new(sorted_items, total_count)
+  end
+
+  def legacy?
+    type == Track.name && @content && LEGACY_PROVIDERS.include?(@content['provider'])
   end
 
   def as_content_json

--- a/app/models/enclosure.rb
+++ b/app/models/enclosure.rb
@@ -36,10 +36,12 @@ class Enclosure < ApplicationRecord
   end
 
   def self.set_contents(enclosures)
+    return enclosures if enclosures.blank?
     contents = fetch_contents(enclosures.map {|t| t.id })
     enclosures.each do |e|
       e.content = contents.select {|c| c["id"] == e.id }.first
     end
+    enclosures
   end
 
   def self.set_marks(user, enclosures)

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -38,7 +38,7 @@ class Entry < ApplicationRecord
       .eager_load(:tracks, :albums, :playlists, :keywords)
   }
   scope :latest,        ->     (time) { where("published > ?", time).order('published DESC').with_content }
-  scope :popular,       ->            { joins(:saved_users).order('saved_count DESC').with_content }
+  scope :hot,           ->            { joins(:saved_users).order('read_count DESC').with_content }
   scope :subscriptions, ->       (ss) { where(feed: ss.map { |s| s.feed_id }).order('published DESC').with_content }
   scope :feed,          ->     (feed) { where(feed: feed).order('published DESC').with_content }
   scope :feeds,         ->    (feeds) { where(feed: feeds).order('published DESC').with_content }

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -237,12 +237,13 @@ class Entry < ApplicationRecord
     h
   end
 
-  def as_content_json
+  def as_content_json(only_legacy: false)
     hash               = as_json
     hash['engagement'] = saved_count
     hash['tags']       = nil
     hash['enclosure']  = [tracks, playlists, albums].flat_map do |items|
-      items.map { |item| item.as_enclosure }
+      items.select {|item| !only_legacy || item.legacy? }
+           .map { |item| item.as_enclosure }
     end
     hash
   end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -120,6 +120,17 @@ class Entry < ApplicationRecord
     end
   end
 
+  def self.set_contents_of_enclosures(entries)
+    track_items    = entries.flat_map {|e| e.tracks }
+    album_items    = entries.flat_map {|e| e.albums }
+    playlist_items = entries.flat_map {|e| e.playlists }
+    {
+      tracks:    Track.set_contents(track_items),
+      albums:    Album.set_contents(album_items),
+      playlists: Playlist.set_contents(playlist_items),
+    }
+  end
+
   def url
     items = JSON.load(alternate)
     items.present? && items[0]['href']

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -1,18 +1,5 @@
 require 'pink_spider'
 class Track < Enclosure
-  def get_content
-    PinkSpider.new.fetch_track(id)
-  end
-
-  def fetch_content
-    @content = get_content
-  end
-
-  def title
-    fetch_content if @content.nil?
-    "#{@content["title"]} / #{@content["owner_name"]}"
-  end
-
   def permalink_url provider, identifier
     fetch_content if @content.nil?
     @content["url"]

--- a/db/migrate/20170302131100_rename_tracks_to_enclosures.rb
+++ b/db/migrate/20170302131100_rename_tracks_to_enclosures.rb
@@ -13,6 +13,7 @@ class RenameTracksToEnclosures < ActiveRecord::Migration[5.0]
     add_index :entry_enclosures, :enclosure_type
 
     rename_column :enclosures, :like_count, :likes_count
+    remove_column :enclosures, :title     , :string
     remove_column :enclosures, :provider  , :string
     remove_column :enclosures, :identifier, :string
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,6 @@ ActiveRecord::Schema.define(version: 20170317151616) do
   end
 
   create_table "enclosures", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "title"
     t.string   "url"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false

--- a/spec/support/api_macros.rb
+++ b/spec/support/api_macros.rb
@@ -26,7 +26,16 @@ module ApiMacros
     {
       Authorization: "Bearer #{@token['access_token']}",
       CONTENT_TYPE:  "application/json",
-      ACCEPT:        "application/json"
+      ACCEPT:        "application/json",
+      "X-Api-Version": "1"
+    }
+  end
+
+  def headers_for_legacy_login_user_api
+    {
+      Authorization: "Bearer #{@token['access_token']}",
+      CONTENT_TYPE:  "application/json",
+      ACCEPT:        "application/json",
     }
   end
 

--- a/spec/v3/streams/tracks_api_spec.rb
+++ b/spec/v3/streams/tracks_api_spec.rb
@@ -93,5 +93,15 @@ RSpec.describe "Track Stream api", type: :request, autodoc: true do
       expect(result['continuation']).to be_nil
     end
 
+    context "legacy_user" do
+      it "gets only legacy tracks" do
+        resource = CGI.escape "user/#{@user.id}/playlist/global.liked"
+        get "/v3/streams/#{resource}/tracks/contents",
+            headers: headers_for_legacy_login_user_api
+        result = JSON.parse @response.body
+        expect(result['items'].count).to eq(0)
+        expect(result['continuation']).to be_nil
+      end
+    end
   end
 end

--- a/spec/v3/streams_api_spec.rb
+++ b/spec/v3/streams_api_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe "Streams api", type: :request, autodoc: true do
           headers: headers_for_login_user_api
       result = JSON.parse @response.body
       expect(result['items'].count).to eq(ENTRY_PER_FEED - PER_PAGE)
+      expect(result['items'][0]['enclosure'].count).to eq(12)
       expect(result['continuation']).to be_nil
     end
 
@@ -189,6 +190,17 @@ RSpec.describe "Streams api", type: :request, autodoc: true do
       result['items'].each { |item|
         expect(Entry.find(item['id']).feed).to eq(@subscription.feed)
       }
+    end
+
+    context "legacy_user" do
+      it "gets entries that includes only legacy tracks" do
+        get "/v3/streams/#{@feed.escape.id}/contents",
+            headers: headers_for_legacy_login_user_api
+        result = JSON.parse @response.body
+        expect(result['items'].count).to eq(PER_PAGE)
+        expect(result['items'][0]['enclosure'].count).to eq(0)
+        expect(result['continuation']).not_to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Use `X-Api-Version` header as api version.

If X-Api-Version 0 (include not-specified), return only legacy enclosure(youtube and spotify track)