### PR TITLE
Entry#as_partial_json

### DIFF
--- a/app/models/enclosure.rb
+++ b/app/models/enclosure.rb
@@ -235,7 +235,7 @@ class Enclosure < ApplicationRecord
     end
 
     if !@partial_entries.nil?
-      hash['entries'] = @partial_entries.map { |e| e.as_json }
+      hash['entries'] = @partial_entries.map { |e| e.as_partial_json }
     end
 
     hash['id'] = id

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -361,8 +361,8 @@ class Entry < ApplicationRecord
     h               = super(options)
     h['crawled']    = crawled.to_time.to_i * 1000
     h['published']  = published.to_time.to_i * 1000
-    h['recrawled']  = recrawled.present? ? recrawled.to_time.to_i * 1000 : nil
-    h['updated']    = updated.present?   ? updated.to_time.to_i   * 1000 : nil
+    h['recrawled']  = recrawled&.to_time&.to_i&.* 1000
+    h['updated']    = updated&.to_time&.to_i&.* 1000
     h['categories'] = []
     h['keywords']   = nil
     h.delete('saved_count')

--- a/spec/factories/feed_factory.rb
+++ b/spec/factories/feed_factory.rb
@@ -56,8 +56,8 @@ FactoryGirl.define do
   factory :entry, class: Entry do
     sequence(:id) { |n| "entry#{n}" }
     sequence(:title) { |n| "entry #{n}" }
-    content         "{\"content\":\"\"}"
-    summary         "null"
+    content         "{\"content\":\"content\"}"
+    summary         "{\"content\":\"summary\"}"
     author          nil
     alternate       "[]"
     origin          "{}"

--- a/spec/v3/entries_api_spec.rb
+++ b/spec/v3/entries_api_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe "Entries api", :type => :request, autodoc: true do
     id = @entries[0].id
     get "/v3/entries/#{id}",
         headers: headers_for_login_user_api
-    entry = JSON.parse @response.body
-    expect(entry).not_to be_nil()
-    expect(entry['id']).to eq(@entries[0].id)
-    expect(entry['tracks'].length).to be > 0
-    expect(entry['tracks'][0]['entries'].length).to be > 0
+    e = JSON.parse @response.body
+    expect(e).not_to be_nil()
+    expect(e['id']).to eq(@entries[0].id)
+    expect(e['tracks'].length).to be > 0
+    expect(e['tracks'][0]['entries'].length).to be > 0
+    expect(e['tracks'][0]['entries'][0]["summary"]).to be_nil
   end
 
   it "shows entries list by id list" do
@@ -31,6 +32,7 @@ RSpec.describe "Entries api", :type => :request, autodoc: true do
       expect(e['id']).to eq(ids[i])
       expect(e['tracks'].length).to be > 0
       expect(e['tracks'][0]['entries'].length).to be > 0
+      expect(e['tracks'][0]['entries'][0]["summary"]).to be_nil
     }
   end
 end

--- a/spec/v3/tracks_api_spec.rb
+++ b/spec/v3/tracks_api_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "Tracks api", :type => :request, autodoc: true do
     expect(track['id']).to eq(id)
     expect(track['entries']).not_to be_nil()
     expect(track['entries'].count).to be(2)
+    expect(track['entries'][0]["summary"]).not_to be_nil
     expect(es[0]['published'] > es[1]['published']).to be_truthy
     expect(track['likers']).not_to be_nil()
     expect(track['likesCount']).to eq(1)
@@ -37,6 +38,7 @@ RSpec.describe "Tracks api", :type => :request, autodoc: true do
     tracks = JSON.parse @response.body
     expect(tracks).not_to be_nil()
     expect(tracks.count).to eq(tracks.count)
+    expect(tracks[0]['entries'][0]["summary"]).not_to be_nil
     tracks.each_with_index {|t, i|
       expect(ids).to include(t['id'])
     }


### PR DESCRIPTION
Enclosures API `should` returns entries with their content and summary,
but Entries API `shouldn't` returns entries of child enclosures(grandchild) with their content and summary
So, implement Entry#as_partial_json for Entries API grandchild entries