### PR TITLE
Engagement scorer

### DIFF
--- a/app/controllers/concerns/v3/streams_controllable.rb
+++ b/app/controllers/concerns/v3/streams_controllable.rb
@@ -153,6 +153,8 @@ module V3::StreamsControllable
       @type = :featured
     when 'picked'
       @type = :picked
+    when 'engaging'
+      @type = :engaging
     else
       @type = :hot
     end

--- a/app/models/concerns/enclosure_engagement_scorer.rb
+++ b/app/models/concerns/enclosure_engagement_scorer.rb
@@ -91,7 +91,7 @@ module EnclosureEngagementScorer
 
       sorted_items = scores.map do |h|
         item = items.select { |t| t.id == h["id"] }.first
-        item.engagement = h["score"]
+        item.engagement = h["score"].to_i
         item
       end
       PaginatedArray.new(sorted_items, total_count)

--- a/app/models/concerns/enclosure_engagement_scorer.rb
+++ b/app/models/concerns/enclosure_engagement_scorer.rb
@@ -1,0 +1,100 @@
+require('paginated_array')
+module EnclosureEngagementScorer
+  extend ActiveSupport::Concern
+
+  Enclosures = Enclosure.arel_table
+  Join       = Arel::Nodes::OuterJoin
+
+  included do
+  end
+
+  class_methods do
+    def select_all(select_mgr, bind_values)
+      visitor     = ActiveRecord::Base.connection.visitor
+      collector   = visitor.accept(select_mgr.ast, Arel::Collectors::Bind.new)
+      sql         = collector.substitute_binds(bind_values).join
+      ActiveRecord::Base.connection.select_all(sql).to_a
+    end
+
+    def score_bind_values(score_tables)
+      score_tables.reduce([]) do |memo, t|
+        v = t.values[:where].binds.map { |bind|
+          ActiveRecord::Base.connection.quote(bind.value_for_database)
+        }
+        memo.concat v
+      end
+    end
+
+    def score_select_mgr(score_tables)
+      score_columns = []
+      query         = Enclosures
+      score_tables.each do |mark|
+        scores = mark.as("#{mark.table_name}_scores")
+        query  = query.join(scores, Join).on(Enclosures[:id].eq(scores[:enclosure_id]))
+        score_columns << "COALESCE(#{scores[:score].sum().to_sql}, 0)"
+      end
+
+      score = score_columns.join(' + ')
+      query
+        .project(Enclosures[:id], "#{score} as score")
+        .where(Enclosures[:type].eq(self.name))
+        .order("score DESC")
+        .group(Enclosures[:id])
+    end
+
+    def most_engaging_items(stream: nil,
+                            locale: nil,
+                            period: nil,
+                            provider: nil,
+                            page: 1,
+                            per_page: 10)
+      played_score    = ENV.fetch("PLAYED_SCORE")   { 1 }
+      liked_score     = ENV.fetch("LIKED_SCORE")    { 5 }
+      saved_score     = ENV.fetch("SAVED_SCORE")    { 5 }
+      featured_score  = ENV.fetch("FEATURED_SCORE") { 10 }
+      picked_score    = ENV.fetch("PICKED_SCORE")   { 20 }
+
+      played    = self.query_for_best_items(PlayedEnclosure, stream, period, locale, provider)
+                    .select("COUNT(played_enclosures.enclosure_id) * #{played_score} as score, played_enclosures.enclosure_id")
+                    .group("enclosure_id")
+
+      liked     = self.query_for_best_items(LikedEnclosure, stream, period, locale, provider)
+                    .select("COUNT(liked_enclosures.enclosure_id) * #{liked_score} as score, liked_enclosures.enclosure_id")
+                    .group("enclosure_id")
+      saved     = self.query_for_best_items(SavedEnclosure, stream, period, locale, provider)
+                    .select("COUNT(saved_enclosures.enclosure_id) * #{saved_score} as score, saved_enclosures.enclosure_id")
+                    .group("enclosure_id")
+      # doesn't support locale, use stream filter instead
+      featured  = self.query_for_best_items(EntryEnclosure, stream, period, nil, provider)
+                    .joins(:entry)
+                    .distinct()
+                    .select("COUNT(entries.feed_id) * #{featured_score} as score, entry_enclosures.enclosure_id")
+                    .group("entries.feed_id")
+                    .group(:enclosure_id)
+      # doesn't support locale, use stream filter instead
+      picked    = self.query_for_best_items(Pick, stream, period, nil, provider)
+                    .select("COUNT(container_id) * #{picked_score} as score, picks.enclosure_id")
+                    .group(:enclosure_id)
+
+      score_tables = [played, liked, saved, featured, picked]
+      bind_values  = self.score_bind_values(score_tables)
+
+      total_count  = Enclosure.where(type: self.name).count
+
+      select_mgr   = self.score_select_mgr(score_tables)
+
+      select_mgr.offset = (page - 1) < 0 ? 0 : (page - 1) * per_page
+      select_mgr.limit  = per_page
+
+      scores      = self.select_all(select_mgr, bind_values)
+      items = self.with_content.find(scores.map {|h| h["id"] })
+
+      sorted_items = scores.map do |h|
+        item = items.select { |t| t.id == h["id"] }.first
+        item.engagement = h["score"]
+        item
+      end
+      PaginatedArray.new(sorted_items, total_count)
+    end
+  end
+end

--- a/app/models/concerns/enclosure_mark.rb
+++ b/app/models/concerns/enclosure_mark.rb
@@ -48,7 +48,7 @@ module EnclosureMark
       elsif s.kind_of?(Issue)
         issue(s)
       else
-        raise Exception.new("Unknown stream")
+        all
       end
     }
   end

--- a/app/models/concerns/entry_mark.rb
+++ b/app/models/concerns/entry_mark.rb
@@ -43,7 +43,7 @@ module EntryMark
       elsif s.kind_of?(Issue)
         issue(s)
       else
-        raise Exception.new("Unknown stream")
+        all
       end
     }
   end

--- a/app/models/concerns/mix.rb
+++ b/app/models/concerns/mix.rb
@@ -90,6 +90,13 @@ module Mix
                               provider: query.provider,
                               page:     page,
                               per_page: per_page)
+    when :engaging
+      clazz.most_engaging_items(stream:   self,
+                                period:   query.period,
+                                locale:   query.locale,
+                                provider: query.provider,
+                                page:     page,
+                                per_page: per_page)
     end
   end
 

--- a/app/models/enclosure.rb
+++ b/app/models/enclosure.rb
@@ -71,7 +71,7 @@ class Enclosure < ApplicationRecord
     elsif s.kind_of?(Issue)
       issue(s)
     else
-      raise Exception.new("Unknown stream")
+      all
     end
   }
 

--- a/app/models/enclosure.rb
+++ b/app/models/enclosure.rb
@@ -1,5 +1,6 @@
 class Enclosure < ApplicationRecord
   LEGACY_PROVIDERS = ["YouTube", "SoundCloud"]
+  attr_accessor :engagement
   attr_accessor :content
   attr_accessor :partial_entries
   include Likable
@@ -267,6 +268,10 @@ class Enclosure < ApplicationRecord
 
     if !@partial_entries.nil?
       hash['entries'] = @partial_entries.map { |e| e.as_partial_json }
+    end
+
+    if !@engagement.nil?
+      hash['engagement'] = @engagement
     end
 
     hash['id'] = id

--- a/app/models/enclosure.rb
+++ b/app/models/enclosure.rb
@@ -6,6 +6,7 @@ class Enclosure < ApplicationRecord
   include Likable
   include Savable
   include Playable
+  include EnclosureEngagementScorer
 
   ENTRIES_LIMIT = 100
   PARTIAL_ENTRIES_LIMIT = 100

--- a/app/models/enclosure.rb
+++ b/app/models/enclosure.rb
@@ -184,6 +184,7 @@ class Enclosure < ApplicationRecord
                                provider: nil,
                                page: 1,
                                per_page: 10)
+    # doesn't support locale, use stream filter instead
     best_items(clazz:        EntryEnclosure,
                count_method: :feed_count,
                stream:       stream,
@@ -200,6 +201,7 @@ class Enclosure < ApplicationRecord
                              provider: nil,
                              page: 1,
                              per_page: 10)
+    # doesn't support locale, use stream filter instead
     best_items(clazz:        Pick,
                count_method: :pick_count,
                stream:       stream,

--- a/app/models/enclosure.rb
+++ b/app/models/enclosure.rb
@@ -207,6 +207,14 @@ class Enclosure < ApplicationRecord
                per_page:     per_page)
   end
 
+  def self.query_for_best_items(clazz, stream, period, locale, provider)
+    clazz.where(enclosure_type: self.name)
+      .stream(stream)
+      .period(period)
+      .locale(locale)
+      .provider(provider)
+  end
+
   def self.best_items(clazz: nil,
                       count_method: :user_count,
                       stream: nil,
@@ -216,11 +224,7 @@ class Enclosure < ApplicationRecord
                       page: 1,
                       per_page: nil)
     raise ArgumentError, "Parameter must be not nil" if period.nil?
-    query = clazz.where(enclosure_type: self.name)
-                 .period(period)
-                 .locale(locale)
-                 .provider(provider)
-    query = query.stream(stream) if stream.present?
+    query = self.query_for_best_items(clazz, stream, period, locale, provider)
     count_hash    = query.public_send(count_method)
     total_count   = count_hash.keys.count
     sorted_hashes = PaginatedArray::sort_and_paginate_count_hash(count_hash,

--- a/app/models/enclosure.rb
+++ b/app/models/enclosure.rb
@@ -32,7 +32,10 @@ class Enclosure < ApplicationRecord
       where(created_at: since..Float::INFINITY).order(created_at: :desc)
     end
   }
-  scope :detail, ->        { includes([:likers]).includes(:entries) }
+
+  scope :with_content, -> { eager_load(:entry_enclosures).eager_load(:entries) }
+  scope :detail      , -> { includes([:likers]).includes(:entries) }
+
   scope :issue , -> (issue) {
     joins(:enclosure_issues)
       .where(enclosure_issues: { issue: issue })
@@ -230,9 +233,7 @@ class Enclosure < ApplicationRecord
     sorted_hashes = PaginatedArray::sort_and_paginate_count_hash(count_hash,
                                                                  page: page,
                                                                  per_page: per_page)
-    items = self.eager_load(:entry_enclosures)
-                .eager_load(:entries)
-                .find(sorted_hashes.map {|h| h[:id] })
+    items = self.with_content.find(sorted_hashes.map {|h| h[:id] })
     sorted_items = sorted_hashes.map {|h|
       items.select { |t| t.id == h[:id] }.first
     }

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -71,7 +71,7 @@ class Entry < ApplicationRecord
     elsif s.kind_of?(Issue)
       issue(s)
     else
-      raise Exception.new("Unknown stream")
+      all
     end
   }
 

--- a/app/views/enclosures/index.html.slim
+++ b/app/views/enclosures/index.html.slim
@@ -85,6 +85,11 @@ table.table.table-striped
         td = "#{enclosure.saved_count || 0} saves"
         td = "#{enclosure.play_count  || 0} plays"
         td
+          - if @type == 'Playlist'
+            - if enclosure.is_active
+              = link_to 'Deactivate', playlist_deactivate_path(enclosure), :class => 'btn btn-xs btn-primary'
+            - else
+              = link_to 'Activate', playlist_activate_path(enclosure), :class => 'btn btn-xs btn-primary'
           - if @entry.present?
             = link_to 'Edit', edit_entry_enclosure_path(entry_enclosure), :class => 'btn btn-xs btn-primary'
             '
@@ -98,11 +103,6 @@ table.table.table-striped
                     :method => :delete,
                     :class => 'btn btn-xs btn-primary'
           - else
-            - if @type == 'Playlist'
-              - if enclosure.is_active
-                = link_to 'Deactivate', playlist_deactivate_path(enclosure), :class => 'btn btn-xs btn-primary'
-              - else
-                = link_to 'Activate', playlist_activate_path(enclosure), :class => 'btn btn-xs btn-primary'
             - if enclosure.is_liked
               = form_for :like, url: like_path, method: :delete do |f|
                 = f.submit 'Unlike', class: 'btn btn-xs btn-primary'

--- a/spec/v3/mixes/tracks_api_spec.rb
+++ b/spec/v3/mixes/tracks_api_spec.rb
@@ -147,6 +147,23 @@ RSpec.describe "Track Mix api", type: :request, autodoc: true do
       end
     end
 
+    context "engaging mix" do
+      it "gets engaging mixes of a topic " do
+        get "/v3/mixes/#{@topic.escape.id}/tracks/contents",
+            params: {
+              type:      :engaging,
+              newerThan: 400.days.ago.to_time.to_i * 1000,
+              olderThan: Time.now.to_i * 1000,
+            },
+            headers: headers_for_login_user_api
+        result = JSON.parse @response.body
+        expect(result['items'].count).to eq(PER_PAGE)
+        expect(result['continuation']).not_to be_nil
+        expect(result['items'][0]["engagement"]).not_to be_nil
+        expect(result['items'][0]["engagement"]).to be > 0
+      end
+    end
+
     context "feed" do
       before do
         get "/v3/mixes/#{@feed.escape.id}/tracks/contents",


### PR DESCRIPTION
enclosure(track, album, playlist)に対する複数の種類のデータに傾斜をかけてスコアリングしてランキングする API を作成(mix api のengaging type) .

それぞれの関連テーブルをそれぞれサブクエリでスコアを掛けつつenclosure_idでCOUNTして、
その結果のスコアテーブルをJOINしてSUMをとる。

実装は、迷ったがArel( v8.0 )を使った。すでに最新のarel 9.0 では一部APIが変わっているので、rails 5.2にあげるときはまた対応が必要そうだが、既存のscopeを再利用できるメリットの方が高いと判断。
